### PR TITLE
:sparkles: create_broadcaster_migrationの追加

### DIFF
--- a/src/backend/app/models/broadcaster.rb
+++ b/src/backend/app/models/broadcaster.rb
@@ -1,0 +1,4 @@
+class Broadcaster < ApplicationRecord
+  # バリデーション
+  validates :id, presence: true, uniqueness: true
+end

--- a/src/backend/db/migrate/20250617133942_create_broadcasters.rb
+++ b/src/backend/db/migrate/20250617133942_create_broadcasters.rb
@@ -1,0 +1,12 @@
+class CreateBroadcasters < ActiveRecord::Migration[8.0]
+  def change
+    create_table :broadcasters, id: false do |t|
+      t.column :id, 'BIGINT PRIMARY KEY'
+      t.string :login
+      t.string :display_name, index: true
+      t.string :profile_image_url
+      t.string :language
+      t.timestamps
+    end
+  end
+end

--- a/src/backend/db/schema.rb
+++ b/src/backend/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_17_125036) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_17_133942) do
+  create_table "broadcasters", id: :bigint, default: nil, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "login"
+    t.string "display_name"
+    t.string "profile_image_url"
+    t.string "language"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["display_name"], name: "index_broadcasters_on_display_name"
+  end
+
   create_table "users", id: :bigint, default: nil, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "login"
     t.string "display_name"

--- a/src/backend/spec/factories/broadcasters.rb
+++ b/src/backend/spec/factories/broadcasters.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :broadcaster do
+    
+  end
+end

--- a/src/backend/spec/factories/broadcasters.rb
+++ b/src/backend/spec/factories/broadcasters.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :broadcaster do
-    
+    id { 1 }
+    login { "sample_user_1" }
+    display_name { "サンプルユーザー1" }
+    profile_image_url { "profile_image_url" }
+    language { "Japanese" }
   end
 end

--- a/src/backend/spec/models/broadcaster_spec.rb
+++ b/src/backend/spec/models/broadcaster_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Broadcaster, type: :model do
   it 'idなしでBroadcasterモデルが生成できない' do
-    broadcaster = Broadcaster.new(id: nil)
+    broadcaster = build(:broadcaster, id: nil)
     expect(broadcaster).not_to be_valid
   end
 
   it '同じidのBroadcasterモデルが登録できない' do
-    broadcaster1 = Broadcaster.create(id: 1)
-    broadcaster2 = Broadcaster.new(id: 1)
+    broadcaster1 = create(:broadcaster, id: 1)
+    broadcaster2 = build(:broadcaster, id: 1)
     expect(broadcaster2).not_to be_valid
   end
 end

--- a/src/backend/spec/models/broadcaster_spec.rb
+++ b/src/backend/spec/models/broadcaster_spec.rb
@@ -2,13 +2,13 @@ require 'rails_helper'
 
 RSpec.describe Broadcaster, type: :model do
   it 'idなしでBroadcasterモデルが生成できない' do
-    user = User.new(id: nil)
-    expect(user).not_to be_valid
+    broadcaster = Broadcaster.new(id: nil)
+    expect(broadcaster).not_to be_valid
   end
 
   it '同じidのBroadcasterモデルが登録できない' do
-    user1 = User.create(id: nil)
-    user2 = User.new(id: nil)
-    expect(user2).not_to be_valid
+    broadcaster1 = Broadcaster.create(id: 1)
+    broadcaster2 = Broadcaster.new(id: 1)
+    expect(broadcaster2).not_to be_valid
   end
 end

--- a/src/backend/spec/models/broadcaster_spec.rb
+++ b/src/backend/spec/models/broadcaster_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Broadcaster, type: :model do
+  it 'idなしでBroadcasterモデルが生成できない' do
+    user = User.new(id: nil)
+    expect(user).not_to be_valid
+  end
+
+  it '同じidのBroadcasterモデルが登録できない' do
+    user1 = User.create(id: nil)
+    user2 = User.new(id: nil)
+    expect(user2).not_to be_valid
+  end
+end


### PR DESCRIPTION
## 実施タスク
create_broadcaster_migrationの追加

## 実施内容
- マイグレーションを追加して適用
- バリデーションを追加
- バリデーションのテストを追加

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - ブロードキャスター情報を管理するための新しいデータベーステーブルが追加されました。
  - ブロードキャスターのモデルが追加され、IDの存在と一意性が保証されます。  
  - ブロードキャスターの表示名にインデックスが追加され、検索性能が向上しました。

- **テスト**
  - ブロードキャスターのIDバリデーションに関するテストが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->