### PR TITLE
:adhesive_bandage: FactoryBotで必要のない冗長性を持っていたので修正

### DIFF
--- a/src/backend/spec/factories/users.rb
+++ b/src/backend/spec/factories/users.rb
@@ -1,19 +1,9 @@
 FactoryBot.define do
   factory :user do
-    trait :user1 do
-      id { 1 }
-      login { "sample_user_1" }
-      display_name { "サンプルユーザー1" }
-      profile_image_url { "profile_image_url_1" }
-      refresh_token { "refresh_token_1" }
-    end
-
-    trait :user2 do
-      id { 2 }
-      login { "sample_user_2" }
-      display_name { "サンプルユーザー2" }
-      profile_image_url { "profile_image_url_2" }
-      refresh_token { "refresh_token_2" }
-    end  
+    id { 1 }
+    login { "sample_user" }
+    display_name { "サンプルユーザー" }
+    profile_image_url { "profile_image_url" }
+    refresh_token { "refresh_token" }
   end
 end

--- a/src/backend/spec/models/user_spec.rb
+++ b/src/backend/spec/models/user_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe User, type: :model do
   end
 
   it '同じidのUserモデルが登録できない' do
-    user1 = create(:user, :user1, id: 1)
-    user2 = build(:user, :user2, id: 1)
+    user1 = create(:user, id: 1)
+    user2 = build(:user, id: 1)
     expect(user2).not_to be_valid
   end
 end


### PR DESCRIPTION
## 実施タスク
FactoryBotで必要のない冗長性を持っていたので修正

## 実施内容
- traitではなく、親ファクトリーを書いておいて、属性の分岐が必要なときに子ファクトリーを追加していく書き方に変更

## その他 / 備考
なし
