### PR TITLE
:sparkles: create_clip_migrationの追加

### DIFF
--- a/src/backend/app/models/clip.rb
+++ b/src/backend/app/models/clip.rb
@@ -1,0 +1,10 @@
+class Clip < ApplicationRecord
+  # 他モデルとの関係
+  belongs_to :broadcaster
+  belongs_to :game
+
+  # バリデーション
+  validates :slug, uniqueness: true
+  validates :broadcaster_id, presence: true
+  validates :game_id, presence: true
+end

--- a/src/backend/app/models/clip.rb
+++ b/src/backend/app/models/clip.rb
@@ -4,7 +4,5 @@ class Clip < ApplicationRecord
   belongs_to :game
 
   # バリデーション
-  validates :slug, uniqueness: true
-  validates :broadcaster_id, presence: true
-  validates :game_id, presence: true
+  validates :slug, presence: true, uniqueness: true
 end

--- a/src/backend/db/migrate/20250618130205_create_clips.rb
+++ b/src/backend/db/migrate/20250618130205_create_clips.rb
@@ -1,7 +1,7 @@
 class CreateClips < ActiveRecord::Migration[8.0]
   def change
     create_table :clips do |t|
-      t.string :slug
+      t.string :slug, null: false
       t.references :broadcaster, null: false, foreign_key: true
       t.string :broadcaster_name
       t.integer :creator_id

--- a/src/backend/db/migrate/20250618130205_create_clips.rb
+++ b/src/backend/db/migrate/20250618130205_create_clips.rb
@@ -1,0 +1,21 @@
+class CreateClips < ActiveRecord::Migration[8.0]
+  def change
+    create_table :clips do |t|
+      t.string :slug
+      t.references :broadcaster, null: false, foreign_key: true
+      t.string :broadcaster_name
+      t.integer :creator_id
+      t.string :creator_name
+      t.references :game, null: false, foreign_key: true
+      t.string :language
+      t.string :title, index: true
+      t.datetime :clip_created_at, index: true
+      t.string :thumbnail_url
+      t.float :duration
+      t.integer :view_count, index: true
+      t.string :search_keywords, index: true
+      t.timestamps
+    end
+    add_index :clips, :slug, unique: true
+  end
+end

--- a/src/backend/db/schema.rb
+++ b/src/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_17_145644) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_18_130205) do
   create_table "broadcasters", id: :bigint, default: nil, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "login"
     t.string "display_name"
@@ -19,6 +19,31 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_17_145644) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["display_name"], name: "index_broadcasters_on_display_name"
+  end
+
+  create_table "clips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "slug"
+    t.bigint "broadcaster_id", null: false
+    t.string "broadcaster_name"
+    t.integer "creator_id"
+    t.string "creator_name"
+    t.bigint "game_id", null: false
+    t.string "language"
+    t.string "title"
+    t.datetime "clip_created_at"
+    t.string "thumbnail_url"
+    t.float "duration"
+    t.integer "view_count"
+    t.string "search_keywords"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["broadcaster_id"], name: "index_clips_on_broadcaster_id"
+    t.index ["clip_created_at"], name: "index_clips_on_clip_created_at"
+    t.index ["game_id"], name: "index_clips_on_game_id"
+    t.index ["search_keywords"], name: "index_clips_on_search_keywords"
+    t.index ["slug"], name: "index_clips_on_slug", unique: true
+    t.index ["title"], name: "index_clips_on_title"
+    t.index ["view_count"], name: "index_clips_on_view_count"
   end
 
   create_table "games", id: :bigint, default: nil, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -38,4 +63,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_17_145644) do
     t.datetime "updated_at", null: false
     t.index ["display_name"], name: "index_users_on_display_name"
   end
+
+  add_foreign_key "clips", "broadcasters"
+  add_foreign_key "clips", "games"
 end

--- a/src/backend/db/schema.rb
+++ b/src/backend/db/schema.rb
@@ -22,7 +22,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_18_130205) do
   end
 
   create_table "clips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "slug"
+    t.string "slug", null: false
     t.bigint "broadcaster_id", null: false
     t.string "broadcaster_name"
     t.integer "creator_id"

--- a/src/backend/spec/factories/clips.rb
+++ b/src/backend/spec/factories/clips.rb
@@ -1,15 +1,15 @@
 FactoryBot.define do
   factory :clip do
-    id { 1 }
-    slug { "RepleteBitterCormorantUWot-tyks4HB68CU1J7Kc" }
-    creator_id { 72207428 }
-    creator_name { "ジョイ君" }
+    sequence(:id) { |n| "#{n}" }
+    sequence(:slug) { |n| "slug-#{n}" }
+    creator_id { 1 }
+    creator_name { "サンプルユーザー" }
     language { "ja" }
-    title { "葛葉をボコボコにする時風" }
-    clip_created_at { "2023-01-23T12:21:47Z" }
-    thumbnail_url { "https://clips-media-assets2.twitch.tv/sFnQmLcpLOBwevAlNSeynA/AT-cm%7CsFnQmLcpLOBwevAlNSeynA-preview-480x272.jpg" }
-    duration { 21.3 }
-    view_count { 14554 }
+    title { "クリップタイトル" }
+    clip_created_at { "2025-01-01T00:00:00Z" }
+    thumbnail_url { "thumbnail-url" }
+    duration { 10.1 }
+    view_count { 10000 }
     association :broadcaster
     association :game
   end

--- a/src/backend/spec/factories/clips.rb
+++ b/src/backend/spec/factories/clips.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :clip do
+    id { 1 }
+    slug { "RepleteBitterCormorantUWot-tyks4HB68CU1J7Kc" }
+    creator_id { 72207428 }
+    creator_name { "ジョイ君" }
+    language { "ja" }
+    title { "葛葉をボコボコにする時風" }
+    clip_created_at { "2023-01-23T12:21:47Z" }
+    thumbnail_url { "https://clips-media-assets2.twitch.tv/sFnQmLcpLOBwevAlNSeynA/AT-cm%7CsFnQmLcpLOBwevAlNSeynA-preview-480x272.jpg" }
+    duration { 21.3 }
+    view_count { 14554 }
+    association :broadcaster
+    association :game
+  end
+end

--- a/src/backend/spec/models/clip_spec.rb
+++ b/src/backend/spec/models/clip_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Clip, type: :model do
+  it '同じslugのclipモデルが登録できない' do
+    clip1 = create(:clip, slug: "duplicate")
+    clip2 = build(:clip, slug: "duplicate")
+    expect(clip2).not_to be_valid
+  end
+
+  it 'broadcasterモデルなしでclipモデルが登録できない' do
+    clip = build(:clip, broadcaster_id: nil)
+    expect(clip).not_to be_valid
+  end
+
+  it 'gameモデルなしでclipモデルが登録できない' do
+    clip = build(:clip, game_id: nil)
+    expect(clip).not_to be_valid
+  end
+end

--- a/src/backend/spec/models/clip_spec.rb
+++ b/src/backend/spec/models/clip_spec.rb
@@ -6,14 +6,4 @@ RSpec.describe Clip, type: :model do
     clip2 = build(:clip, slug: "duplicate")
     expect(clip2).not_to be_valid
   end
-
-  it 'broadcasterモデルなしでclipモデルが登録できない' do
-    clip = build(:clip, broadcaster_id: nil)
-    expect(clip).not_to be_valid
-  end
-
-  it 'gameモデルなしでclipモデルが登録できない' do
-    clip = build(:clip, game_id: nil)
-    expect(clip).not_to be_valid
-  end
 end


### PR DESCRIPTION
## 実施タスク
create_clip_migrationの追加

## 実施内容
- マイグレーションを追加して適用
- バリデーションの追加
- バリデーションのテストを追加
- テストに必要な最低限のアソシエーション(他モデルとの関係)を追加

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - クリップ情報を管理する新しい「クリップ」機能を追加しました。クリップごとにブロードキャスターやゲームとの関連付け、タイトル、作成日時、サムネイル、再生回数などの情報が保存されます。

- **テスト**
  - クリップ機能に対するバリデーションテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->