### PR TITLE
:sparkles: create_playlist_migrationの追加

### DIFF
--- a/src/backend/app/models/playlist.rb
+++ b/src/backend/app/models/playlist.rb
@@ -1,0 +1,8 @@
+class Playlist < ApplicationRecord
+  # 他モデルとの関係
+  belongs_to :user
+
+  # バリデーション
+  validates :slug, presence: true, uniqueness: true
+  validates :public, presence: true
+end

--- a/src/backend/db/migrate/20250619133059_create_playlists.rb
+++ b/src/backend/db/migrate/20250619133059_create_playlists.rb
@@ -1,0 +1,14 @@
+class CreatePlaylists < ActiveRecord::Migration[8.0]
+  def change
+    create_table :playlists do |t|
+      t.string :slug, null: false
+      t.string :title, index: true
+      t.references :user, null: false, foreign_key: true
+      t.string :search_keywords, index: true
+      t.boolean :public, null: false, default: true
+      t.timestamps
+    end
+    add_index :playlists, :slug, unique: true
+    add_index :playlists, :created_at
+  end
+end

--- a/src/backend/db/schema.rb
+++ b/src/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_18_130205) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_19_133059) do
   create_table "broadcasters", id: :bigint, default: nil, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "login"
     t.string "display_name"
@@ -54,6 +54,21 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_18_130205) do
     t.index ["name"], name: "index_games_on_name"
   end
 
+  create_table "playlists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "slug", null: false
+    t.string "title"
+    t.bigint "user_id", null: false
+    t.string "search_keywords"
+    t.boolean "public", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["created_at"], name: "index_playlists_on_created_at"
+    t.index ["search_keywords"], name: "index_playlists_on_search_keywords"
+    t.index ["slug"], name: "index_playlists_on_slug", unique: true
+    t.index ["title"], name: "index_playlists_on_title"
+    t.index ["user_id"], name: "index_playlists_on_user_id"
+  end
+
   create_table "users", id: :bigint, default: nil, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "login"
     t.string "display_name"
@@ -66,4 +81,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_18_130205) do
 
   add_foreign_key "clips", "broadcasters"
   add_foreign_key "clips", "games"
+  add_foreign_key "playlists", "users"
 end

--- a/src/backend/spec/factories/playlists.rb
+++ b/src/backend/spec/factories/playlists.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :playlist do
-    sequence(:id) { |n| "#{n}" }
     sequence(:slug) { |n| "slug-#{n}" }
     title { "テストタイトル" }
     public { true }

--- a/src/backend/spec/factories/playlists.rb
+++ b/src/backend/spec/factories/playlists.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :playlist do
+    sequence(:id) { |n| "#{n}" }
+    sequence(:slug) { |n| "slug-#{n}" }
+    title { "テストタイトル" }
+    public { true }
+    association :user
+  end
+end

--- a/src/backend/spec/models/playlist_spec.rb
+++ b/src/backend/spec/models/playlist_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Playlist, type: :model do
   end
 
   it 'publicなしでplaylistモデルを生成できない' do
-    playlist = build(:playlist, slug: nil)
+    playlist = build(:playlist, public: nil)
     expect(playlist).not_to be_valid
   end
 end

--- a/src/backend/spec/models/playlist_spec.rb
+++ b/src/backend/spec/models/playlist_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe Playlist, type: :model do
+  it 'slugなしでplaylistモデルを生成できない' do
+    playlist = build(:playlist, slug: nil)
+    expect(playlist).not_to be_valid
+  end
+
+  it '同じslugのplaylistモデルを登録できない' do
+    playlist1 = create(:playlist, slug: "duplicate")
+    playlist2 = build(:playlist, slug: "duplicate")
+    expect(playlist2).not_to be_valid
+  end
+
+  it 'publicなしでplaylistモデルを生成できない' do
+    playlist = build(:playlist, slug: nil)
+    expect(playlist).not_to be_valid
+  end
+end


### PR DESCRIPTION
## 実施タスク
create_playlist_migrationの追加

## 実施内容
- マイグレーションを追加して適用
- バリデーションを追加
- バリデーションのテストを追加
- テストに必要な最低限のアソシエーション(他モデルとの関係)を追加

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - プレイリスト機能を追加しました。各プレイリストはユーザーに紐づき、公開設定や一意なスラッグ（識別子）を持ちます。

- **テスト**
  - プレイリストのバリデーションに関するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->