### PR TITLE
:sparkles: create_playlist_clip_migrationの追加

### DIFF
--- a/src/backend/app/models/clip.rb
+++ b/src/backend/app/models/clip.rb
@@ -2,6 +2,8 @@ class Clip < ApplicationRecord
   # 他モデルとの関係
   belongs_to :broadcaster
   belongs_to :game
+  has_many :playlist_clips, dependent: :destroy
+  has_many :playlists, through: :playlist_clips
 
   # バリデーション
   validates :slug, presence: true, uniqueness: true

--- a/src/backend/app/models/playlist.rb
+++ b/src/backend/app/models/playlist.rb
@@ -1,6 +1,8 @@
 class Playlist < ApplicationRecord
   # 他モデルとの関係
   belongs_to :user
+  has_many :playlist_clips, dependent: :destroy
+  has_many :clips, through: :playlist_clips
 
   # バリデーション
   validates :slug, presence: true, uniqueness: true

--- a/src/backend/app/models/playlist_clip.rb
+++ b/src/backend/app/models/playlist_clip.rb
@@ -1,0 +1,8 @@
+class PlaylistClip < ApplicationRecord
+  # 他モデルとの関係
+  belongs_to :playlist
+  belongs_to :clip
+  
+  # バリデーション
+  validates :playlist_id, uniqueness: { scope: :clip_id }
+end

--- a/src/backend/db/migrate/20250619141450_create_playlist_clips.rb
+++ b/src/backend/db/migrate/20250619141450_create_playlist_clips.rb
@@ -1,0 +1,10 @@
+class CreatePlaylistClips < ActiveRecord::Migration[8.0]
+  def change
+    create_table :playlist_clips do |t|
+      t.references :playlist, null: false, foreign_key: true
+      t.references :clip, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :playlist_clips, [:playlist_id, :clip_id], unique: true
+  end
+end

--- a/src/backend/db/schema.rb
+++ b/src/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_19_133059) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_19_141450) do
   create_table "broadcasters", id: :bigint, default: nil, charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "login"
     t.string "display_name"
@@ -54,6 +54,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_19_133059) do
     t.index ["name"], name: "index_games_on_name"
   end
 
+  create_table "playlist_clips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "playlist_id", null: false
+    t.bigint "clip_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["clip_id"], name: "index_playlist_clips_on_clip_id"
+    t.index ["playlist_id", "clip_id"], name: "index_playlist_clips_on_playlist_id_and_clip_id", unique: true
+    t.index ["playlist_id"], name: "index_playlist_clips_on_playlist_id"
+  end
+
   create_table "playlists", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "slug", null: false
     t.string "title"
@@ -81,5 +91,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_19_133059) do
 
   add_foreign_key "clips", "broadcasters"
   add_foreign_key "clips", "games"
+  add_foreign_key "playlist_clips", "clips"
+  add_foreign_key "playlist_clips", "playlists"
   add_foreign_key "playlists", "users"
 end

--- a/src/backend/spec/factories/playlist_clips.rb
+++ b/src/backend/spec/factories/playlist_clips.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :playlist_clip do
+    association :playlist
+    association :clip
+  end
+end

--- a/src/backend/spec/models/playlist_clip_spec.rb
+++ b/src/backend/spec/models/playlist_clip_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe PlaylistClip, type: :model do
+  it '同じplaylistとclipのペアを登録できない' do
+    playlist = create(:playlist)
+    clip = create(:clip)
+    playlist_clip1 = create(:playlist_clip, playlist: playlist, clip: clip)
+    playlist_clip2 = build(:playlist_clip, playlist: playlist, clip: clip)
+    expect(playlist_clip2).not_to be_valid
+  end
+end


### PR DESCRIPTION
## 実施タスク
create_playlist_clip_migrationの追加

## 実施内容
- マイグレーションを追加して適用
- バリデーションの追加
- バリデーションのテストを追加
- テストに必要な最低限のアソシエーション(他モデルとの関係)を追加

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - プレイリストとクリップ間の多対多の関連付けが可能になりました。これにより、1つのプレイリストに複数のクリップを追加でき、クリップも複数のプレイリストに含めることができます。

- **テスト**
  - プレイリストとクリップの重複登録を防ぐためのテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->