### PR TITLE
:+1: PlaylistClipモデルにorderを追加

### DIFF
--- a/src/backend/app/models/playlist_clip.rb
+++ b/src/backend/app/models/playlist_clip.rb
@@ -5,4 +5,5 @@ class PlaylistClip < ApplicationRecord
   
   # バリデーション
   validates :playlist_id, uniqueness: { scope: :clip_id }
+  validates :order, presence: true
 end

--- a/src/backend/db/migrate/20250619141450_create_playlist_clips.rb
+++ b/src/backend/db/migrate/20250619141450_create_playlist_clips.rb
@@ -3,6 +3,7 @@ class CreatePlaylistClips < ActiveRecord::Migration[8.0]
     create_table :playlist_clips do |t|
       t.references :playlist, null: false, foreign_key: true
       t.references :clip, null: false, foreign_key: true
+      t.integer :order, null: false, default: 1
       t.timestamps
     end
     add_index :playlist_clips, [:playlist_id, :clip_id], unique: true

--- a/src/backend/db/schema.rb
+++ b/src/backend/db/schema.rb
@@ -67,6 +67,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_19_150336) do
   create_table "playlist_clips", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "playlist_id", null: false
     t.bigint "clip_id", null: false
+    t.integer "order", default: 1, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["clip_id"], name: "index_playlist_clips_on_clip_id"

--- a/src/backend/spec/factories/playlist_clips.rb
+++ b/src/backend/spec/factories/playlist_clips.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :playlist_clip do
+    order { 1 }
     association :playlist
     association :clip
   end

--- a/src/backend/spec/models/playlist_clip_spec.rb
+++ b/src/backend/spec/models/playlist_clip_spec.rb
@@ -8,4 +8,11 @@ RSpec.describe PlaylistClip, type: :model do
     playlist_clip2 = build(:playlist_clip, playlist: playlist, clip: clip)
     expect(playlist_clip2).not_to be_valid
   end
+
+  it 'orderなしでplaylist_clipモデルを生成できない' do
+    playlist = create(:playlist)
+    clip = create(:clip)
+    playlist_clip = build(:playlist_clip, playlist: playlist, clip: clip, order: nil)
+    expect(playlist_clip).not_to be_valid
+  end
 end


### PR DESCRIPTION
## 実施タスク
PlaylistClipモデルにorderを追加

## 実施内容
- マイグレーションを追加して適用
- バリデーションの追加
- バリデーションのテストを追加

## その他 / 備考
なし
