### PR TITLE
:+1: モデルに足りていないアソシエーションを追加

### DIFF
--- a/src/backend/app/models/broadcaster.rb
+++ b/src/backend/app/models/broadcaster.rb
@@ -1,4 +1,7 @@
 class Broadcaster < ApplicationRecord
+  # 他モデルとの関係
+  has_many :clips, dependent: :destroy
+
   # バリデーション
   validates :id, presence: true, uniqueness: true
 end

--- a/src/backend/app/models/game.rb
+++ b/src/backend/app/models/game.rb
@@ -1,4 +1,7 @@
 class Game < ApplicationRecord
+  # 他モデルとの関係
+  has_many :clips
+
   # バリデーション
   validates :id, presence: true, uniqueness: true
 end

--- a/src/backend/app/models/user.rb
+++ b/src/backend/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   # 他モデルとの関係
+  has_many :playlists, dependent: :destroy
   has_many :favorites, dependent: :destroy
   has_many :fav_playlists, through: :favorites, source: :playlist
 


### PR DESCRIPTION
## 実施タスク
モデルに足りていないアソシエーションを追加

## 実施内容
- broadcaster, game, userに相手側のbelongs_toに対応するhas_manyを追加

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ブロードキャスターが削除されると関連するクリップも自動的に削除されるようになりました。
  - ゲームごとに複数のクリップを管理できるようになりました。
  - ユーザーが削除されると関連するプレイリストも自動的に削除されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->