### PR TITLE
:sparkles: コールバックの追加

### DIFF
--- a/src/backend/app/models/clip.rb
+++ b/src/backend/app/models/clip.rb
@@ -9,5 +9,5 @@ class Clip < ApplicationRecord
   validates :slug, presence: true, uniqueness: true
 
   # コールバック
-  before_save { self.search_keywords = "#{self.title} #{self.broadcaster.display_name} #{self.game.name}" }
+  before_save { self.search_keywords = "#{self&.title} #{self.broadcaster&.display_name} #{self.game&.name}" }
 end

--- a/src/backend/app/models/clip.rb
+++ b/src/backend/app/models/clip.rb
@@ -7,4 +7,7 @@ class Clip < ApplicationRecord
 
   # バリデーション
   validates :slug, presence: true, uniqueness: true
+
+  # コールバック
+  before_save { self.search_keywords = "#{self.title} #{self.broadcaster.display_name} #{self.game.name}" }
 end

--- a/src/backend/app/models/playlist.rb
+++ b/src/backend/app/models/playlist.rb
@@ -7,6 +7,10 @@ class Playlist < ApplicationRecord
   has_many :fav_users, through: :favorites, source: :user
 
   # バリデーション
-  validates :slug, presence: true, uniqueness: true
+  validates :slug, uniqueness: true
   validates :public, presence: true
+
+  # コールバック
+  before_create { self.slug = SecureRandom.uuid }
+  before_save { self.search_keywords = "#{self.title} #{self.user.display_name}" }
 end

--- a/src/backend/app/models/playlist.rb
+++ b/src/backend/app/models/playlist.rb
@@ -12,5 +12,5 @@ class Playlist < ApplicationRecord
 
   # コールバック
   before_create { self.slug = SecureRandom.uuid }
-  before_save { self.search_keywords = "#{self.title} #{self.user.display_name}" }
+  before_save { self.search_keywords = "#{self&.title} #{self.user&.display_name}" }
 end

--- a/src/backend/spec/models/clip_spec.rb
+++ b/src/backend/spec/models/clip_spec.rb
@@ -19,4 +19,3 @@ RSpec.describe Clip, type: :model do
     expect(clip.search_keywords).not_to eq(nil)
   end
 end
- 

--- a/src/backend/spec/models/clip_spec.rb
+++ b/src/backend/spec/models/clip_spec.rb
@@ -11,4 +11,12 @@ RSpec.describe Clip, type: :model do
     clip2 = build(:clip, slug: "duplicate")
     expect(clip2).not_to be_valid
   end
+
+  it 'search_keywordsへのbefore_saveが正常に機能している' do
+    clip = build(:clip)
+    expect(clip.search_keywords).to eq(nil)
+    clip.save!
+    expect(clip.search_keywords).not_to eq(nil)
+  end
 end
+ 

--- a/src/backend/spec/models/clip_spec.rb
+++ b/src/backend/spec/models/clip_spec.rb
@@ -12,10 +12,9 @@ RSpec.describe Clip, type: :model do
     expect(clip2).not_to be_valid
   end
 
-  it 'search_keywordsへのbefore_saveが正常に機能している' do
-    clip = build(:clip)
-    expect(clip.search_keywords).to eq(nil)
+  it 'search_keywordsは保存時に自動生成される' do
+    clip = build(:clip, search_keywords: nil)
     clip.save!
-    expect(clip.search_keywords).not_to eq(nil)
+    expect(clip.search_keywords).not_to be_nil
   end
 end

--- a/src/backend/spec/models/playlist_spec.rb
+++ b/src/backend/spec/models/playlist_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Playlist, type: :model do
-  it 'slugは保存時に自動生成される' do
+  it 'slugは初回保存時に自動生成される' do
     playlist = build(:playlist, slug: nil)
     playlist.save!
-    expect(playlist.slug).not_to be_valid
+    expect(playlist.slug).not_to be_nil
   end
 
   it 'publicなしでplaylistモデルを生成できない' do
@@ -12,10 +12,9 @@ RSpec.describe Playlist, type: :model do
     expect(playlist).not_to be_valid
   end
 
-  it 'search_keywordsへのbefore_saveが正常に機能している' do
-    playlist = build(:playlist)
-    expect(playlist.search_keywords).to eq(nil)
+  it 'search_keywordsは保存時に自動生成される' do
+    playlist = build(:playlist, search_keywords: nil)
     playlist.save!
-    expect(playlist.search_keywords).not_to eq(nil)
+    expect(playlist.search_keywords).not_to be_nil
   end
 end

--- a/src/backend/spec/models/playlist_spec.rb
+++ b/src/backend/spec/models/playlist_spec.rb
@@ -1,19 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Playlist, type: :model do
-  it 'slugなしでplaylistモデルを生成できない' do
+  it 'slugは保存時に自動生成される' do
     playlist = build(:playlist, slug: nil)
-    expect(playlist).not_to be_valid
-  end
-
-  it '同じslugのplaylistモデルを登録できない' do
-    playlist1 = create(:playlist, slug: "duplicate")
-    playlist2 = build(:playlist, slug: "duplicate")
-    expect(playlist2).not_to be_valid
+    playlist.save!
+    expect(playlist.slug).not_to be_valid
   end
 
   it 'publicなしでplaylistモデルを生成できない' do
     playlist = build(:playlist, public: nil)
     expect(playlist).not_to be_valid
+  end
+
+  it 'search_keywordsへのbefore_saveが正常に機能している' do
+    playlist = build(:playlist)
+    expect(playlist.search_keywords).to eq(nil)
+    playlist.save!
+    expect(playlist.search_keywords).not_to eq(nil)
   end
 end


### PR DESCRIPTION
## 実施タスク
コールバックの追加

## 実施内容
- Clipモデルのsearch_keywordsにsave前にクリップタイトル+配信者名+ゲーム名の文字列を挿入するように追加
- Playlistモデルのsearch_keywordsにsave前にプレイリストタイトル+作成ユーザー名の文字列を挿入するように追加
- Plyalistモデルのslugにcreate前にUUIDを生成して挿入するように追加。それに伴い、必要なくなったバリデーションやテストを削除
- 各種テストの追加

## その他 / 備考
before_createでslugを生成しているので、バリデーションにpresenceは必要なくなり、uniquenessは構造上テストできなくなったので該当のテストを削除。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - クリップとプレイリストの保存時に、検索用キーワードが自動的に生成されるようになりました。
  - プレイリストの保存時にスラッグ（slug）が自動生成されるようになりました。

- **バグ修正**
  - プレイリストのスラッグの一意性のみが検証され、必須ではなくなりました。

- **テスト**
  - クリップとプレイリストの検索キーワード自動生成、およびプレイリストのスラッグ自動生成に関するテストが追加・修正されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->