### PR TITLE
:+1: 代理IDの追加

### DIFF
--- a/src/backend/app/models/clip.rb
+++ b/src/backend/app/models/clip.rb
@@ -1,4 +1,8 @@
 class Clip < ApplicationRecord
+  # 代理IDの設定
+  include FriendlyId
+  friendly_id :slug, use: :finders
+
   # 他モデルとの関係
   belongs_to :broadcaster
   belongs_to :game

--- a/src/backend/app/models/playlist.rb
+++ b/src/backend/app/models/playlist.rb
@@ -1,4 +1,8 @@
 class Playlist < ApplicationRecord
+  # 代理IDの設定
+  include FriendlyId
+  friendly_id :slug, use: :finders
+
   # 他モデルとの関係
   belongs_to :user
   has_many :playlist_clips, dependent: :destroy

--- a/src/backend/spec/models/clip_spec.rb
+++ b/src/backend/spec/models/clip_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe Clip, type: :model do
     expect(clip2).not_to be_valid
   end
 
+  it 'slugで検索できる' do
+    clip = create(:clip)
+    found_clip = Clip.friendly.find(clip.slug)
+    expect(found_clip).to eq(clip)
+  end
+
   it 'search_keywordsは保存時に自動生成される' do
     clip = build(:clip, search_keywords: nil)
     clip.save!

--- a/src/backend/spec/models/playlist_spec.rb
+++ b/src/backend/spec/models/playlist_spec.rb
@@ -7,6 +7,12 @@ RSpec.describe Playlist, type: :model do
     expect(playlist.slug).not_to be_nil
   end
 
+  it 'slugで検索できる' do
+    playlist = create(:playlist)
+    found_playlist = Playlist.friendly.find(playlist.slug)
+    expect(found_playlist).to eq(playlist)
+  end
+
   it 'publicなしでplaylistモデルを生成できない' do
     playlist = build(:playlist, public: nil)
     expect(playlist).not_to be_valid


### PR DESCRIPTION
## 実施タスク
代理IDの追加

## 実施内容
- clipとplaylistのslugに代理IDを設定
- 同時にfriendly.find()で検索できるかのテストを作成

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 「Clip」と「Playlist」で人間が読みやすいスラッグ（slug）を使ったフレンドリーURLでのアクセスが可能になりました。

- **テスト**
  - スラッグを利用した検索が正しく動作することを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->