### PR TITLE
:sparkles: Twitch APIへリクエストするときのヘッダーを作成

### DIFF
--- a/src/backend/app/controllers/application_controller.rb
+++ b/src/backend/app/controllers/application_controller.rb
@@ -1,2 +1,19 @@
 class ApplicationController < ActionController::API
+  def twitch_api_header(type, current_user = nil)
+    if type == "app-access-token"
+      {
+        "Authorization" => ENV["APP_ACCESS_TOKEN"],
+        "Client-id" => ENV["CLIENT_ID"]
+      }
+    elsif type == "user-access-token"
+      {
+        "Authorization" => current_user.user_access_token,
+        "Client-id" => ENV["CLIENT_ID"]
+      }
+    elsif type == "www-form"
+      {
+        'Content-Type': "application/x-www-form-urlencoded"
+      }
+    end
+  end
 end

--- a/src/backend/app/controllers/application_controller.rb
+++ b/src/backend/app/controllers/application_controller.rb
@@ -1,18 +1,25 @@
 class ApplicationController < ActionController::API
+  private
+
+  # Twitch APIへのリクエストのヘッダー
   def twitch_api_header(type, current_user = nil)
+    return nil if type.blank?
+
     if type == "app-access-token"
+      return nil if ENV["APP_ACCESS_TOKEN"].blank? || ENV["CLIENT_ID"].blank?
       {
         "Authorization" => ENV["APP_ACCESS_TOKEN"],
         "Client-id" => ENV["CLIENT_ID"]
       }
     elsif type == "user-access-token"
+      return nil if current_user.nil? || current_user.user_access_token.blank? || ENV["CLIENT_ID"].blank?
       {
         "Authorization" => current_user.user_access_token,
         "Client-id" => ENV["CLIENT_ID"]
       }
     elsif type == "www-form"
       {
-        'Content-Type': "application/x-www-form-urlencoded"
+        "Content-Type" => "application/x-www-form-urlencoded"
       }
     end
   end


### PR DESCRIPTION
## 実施タスク
Twitch APIへリクエストするときのヘッダーを作成

## 実施内容
以下3種類のヘッダーを作成し、1つにまとめた
- app-access-tokenを使用するヘッダー
- user-access-tokenを使用するヘッダー
- contents-typeを指定するヘッダー

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - Twitch APIリクエスト用の認証ヘッダーを生成する機能が追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->