### PR TITLE
:tada: BroadcastersController(actions: index, create)の作成

### DIFF
--- a/src/backend/app/controllers/application_controller.rb
+++ b/src/backend/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::API
+  # すべてのコントローラにHttpDealerをincludeする
+  include HttpDealer
 end

--- a/src/backend/app/controllers/broadcasters_controller.rb
+++ b/src/backend/app/controllers/broadcasters_controller.rb
@@ -1,0 +1,71 @@
+class BroadcastersController < ApplicationController
+  # 日本の配信者の一覧を出力(id, nameを指定可)
+  def index
+    if params[:only_ids]
+      render status: :ok, json: Broadcaster.where(language: "ja").map(&:id)
+    else
+      render status: :ok, json: Broadcaster.where(language: "ja").map(&:display_name)
+    end
+  end
+
+  # 配信者を登録
+  def create
+    # 入力
+    clip_id = params[:clip_id]
+    broadcaster_id = params[:broadcaster_id] || get_broadcaster_id(clip_id)
+
+    # 準備
+    header = { "Authorization" => ENV["APP_ACCESS_TOKEN"],  "Client-id" => ENV["CLIENT_ID"] }
+    uri = "https://api.twitch.tv/helix/users?id=#{broadcaster_id}"
+
+    # 中断処理
+    if @broadcaster = Broadcaster.find_by(id: broadcaster_id)
+      render status: :ok, json: @broadcaster
+      return
+    end
+
+    # データ取得
+    response = get_request(header, uri)
+    data = response["data"][0]
+
+    # 配信者を作成
+    @broadcaster = Broadcaster.create!(id: data["id"],
+                                      login: data["login"],
+                                      display_name: data["display_name"],
+                                      language: get_first_clip_language(broadcaster_id),
+                                      profile_image_url: data["profile_image_url"])
+
+    # 出力
+    render status: :created, json: @broadcaster
+  end
+
+  private
+
+  # 配信者IDを取得する関数
+  def get_broadcaster_id(clip_id)
+    # 準備
+    header = { "Authorization" => ENV["APP_ACCESS_TOKEN"],  "Client-id" => ENV["CLIENT_ID"] }
+    uri = "https://api.twitch.tv/helix/clips?id=#{clip_id}"
+
+    # データ取得
+    response = get_request(header, uri)
+    data = response["data"][0]
+
+    # 出力
+    broadcaster_id = data["broadcaster_id"]
+  end
+
+  # 配信者の最も人気なクリップの言語を取得する関数
+  def get_first_clip_language(broadcaster_id)
+    # 準備
+    header = { "Authorization" => ENV["APP_ACCESS_TOKEN"],  "Client-id" => ENV["CLIENT_ID"] }
+    uri = "https://api.twitch.tv/helix/clips?broadcaster_id=#{broadcaster_id}&first=1"
+
+    # データ取得
+    response = get_request(header, uri)
+    data = response["data"][0]
+
+    # 出力
+    data["language"]
+  end
+end

--- a/src/backend/app/controllers/broadcasters_controller.rb
+++ b/src/backend/app/controllers/broadcasters_controller.rb
@@ -15,7 +15,6 @@ class BroadcastersController < ApplicationController
     broadcaster_id = params[:broadcaster_id] || get_broadcaster_id(clip_id)
 
     # 準備
-    header = { "Authorization" => ENV["APP_ACCESS_TOKEN"],  "Client-id" => ENV["CLIENT_ID"] }
     uri = "https://api.twitch.tv/helix/users?id=#{broadcaster_id}"
 
     # 中断処理
@@ -25,7 +24,7 @@ class BroadcastersController < ApplicationController
     end
 
     # データ取得
-    response = get_request(header, uri)
+    response = get_request(twitch_api_header("app-access-token"), uri)
     data = response["data"][0]
 
     # 配信者を作成
@@ -44,11 +43,10 @@ class BroadcastersController < ApplicationController
   # 配信者IDを取得する関数
   def get_broadcaster_id(clip_id)
     # 準備
-    header = { "Authorization" => ENV["APP_ACCESS_TOKEN"],  "Client-id" => ENV["CLIENT_ID"] }
     uri = "https://api.twitch.tv/helix/clips?id=#{clip_id}"
 
     # データ取得
-    response = get_request(header, uri)
+    response = get_request(twitch_api_header("app-access-token"), uri)
     data = response["data"][0]
 
     # 出力
@@ -58,11 +56,10 @@ class BroadcastersController < ApplicationController
   # 配信者の最も人気なクリップの言語を取得する関数
   def get_first_clip_language(broadcaster_id)
     # 準備
-    header = { "Authorization" => ENV["APP_ACCESS_TOKEN"],  "Client-id" => ENV["CLIENT_ID"] }
     uri = "https://api.twitch.tv/helix/clips?broadcaster_id=#{broadcaster_id}&first=1"
 
     # データ取得
-    response = get_request(header, uri)
+    response = get_request(twitch_api_header("app-access-token"), uri)
     data = response["data"][0]
 
     # 出力

--- a/src/backend/config/routes.rb
+++ b/src/backend/config/routes.rb
@@ -1,10 +1,6 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
+  scope :api do
+    # broadcasters
+    resources :broadcasters, only: %i[index create]
+  end
 end

--- a/src/backend/spec/requests/broadcasters_spec.rb
+++ b/src/backend/spec/requests/broadcasters_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.describe "Broadcasters", type: :request do
+  describe "GET /broadcasters" do
+    it 'broadcasterのdisplay_nameの一覧を取得できる' do
+      @broadcaster = create(:broadcaster)
+      get broadcasters_path
+      data = JSON.parse(response.body)
+      expect(data).to include(@broadcaster.display_name)
+      expect(response).to have_http_status(200)
+    end
+
+    it 'broadcasterのidの一覧を取得できる' do
+      @broadcaster = create(:broadcaster)
+      get broadcasters_path, params: { only_ids: true }
+      data = JSON.parse(response.body)
+      expect(data).to include(@broadcaster.id)
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe "POST /broadcasters" do
+    it 'broadcaster_idからbroadcasterを作成できる' do
+      expect {
+        post broadcasters_path, params: { broadcaster_id: 807966915 }
+      }.to change(Broadcaster, :count).by(1)
+      expect(response).to have_http_status(201)
+    end
+
+    it 'clip_idからbroadcasterを作成できる' do
+      expect {
+        post broadcasters_path, params: { clip_id: "RepleteBitterCormorantUWot-tyks4HB68CU1J7Kc" }
+      }.to change(Broadcaster, :count).by(1)
+      expect(response).to have_http_status(201)
+    end
+  end
+end


### PR DESCRIPTION
## 実施タスク
BroadcastersController(actions: index, create)の作成

## 実施内容
- BroadcastersControllerの作成
  - indexとcreateのルーティングの作成
  - indexとして配信者の一覧を出力するアクション、そしてそのテストを作成
  - createとして配信者を登録するアクション、そしてそのテストを作成
  - 配信者IDを取得する関数と配信者の最も人気なクリップの言語を取得する関数を作成

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 日本語ブロードキャスターの一覧取得および新規登録APIエンドポイントを追加しました。
- **ルーティング**
  - `/api/broadcasters` に `index`（一覧取得）および `create`（新規登録）のルートを追加しました。
- **テスト**
  - ブロードキャスターAPIのGET・POSTリクエストに対するリクエストスペックを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->