### PR TITLE
:gear: Gem汚染が発生したので、対策としてbundleだけvolumeに退避

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       # カレントディレクトリの内容をコンテナ内の/appにマウントする
       - ./src/backend:/app
+      - bundle:/usr/local/bundle # gem インストール先を volume に退避
     env_file:
       - .env
     ports:
@@ -45,3 +46,4 @@ services:
       - ${NEXTJS_PORT}:3000 # 環境変数（.env）から参照
 volumes:
   db-data:
+  bundle: 

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:3.2.2
 
 # 環境変数
 ENV APP_HOME /app
+ENV BUNDLE_PATH=/usr/local/bundle
 
 # 作業ディレクトリ指定
 WORKDIR ${APP_HOME}


### PR DESCRIPTION
## 実施タスク
Gem汚染が発生したので、対策としてbundleだけvolumeに退避

## 実施内容
- bundleのパスを追加
- bundleのパスをvolumeにマウント

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - バックエンドサービスのDockerコンテナでRuby gemsの永続化ストレージを追加しました。

- **その他**
  - Docker環境の設定が更新され、gemインストール先が分離されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->