### PR TITLE
:gear: 新しいgemの追加

### DIFF
--- a/src/backend/Gemfile
+++ b/src/backend/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 gem "rails", "~> 8.0.2"
 gem "mysql2", "~> 0.5"
 gem "puma", ">= 5.0"
+gem "rake", "~> 13.3"
 gem "tzinfo-data", platforms: %i[ windows jruby ]
 gem "solid_cache"
 gem "solid_queue"
@@ -24,4 +25,8 @@ group :development, :test do
   gem "rubocop-rails-omakase", require: false
   gem "rspec-rails"
   gem "factory_bot_rails"
+end
+
+group :test do
+  gem "webmock"
 end


### PR DESCRIPTION
## 実施タスク
新しいgemの追加

## 実施内容
- 外部APIをモックするためのwebmock gemを追加
- webmockで使用するrake gemを追加

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - すべての環境で「rake」バージョン「~> 13.3」を依存関係に追加しました。
  - テスト環境専用で「webmock」gemを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->