### PR TITLE
:recycle: broadcasters_controllerのリファクタリング

### DIFF
--- a/src/backend/app/controllers/application_controller.rb
+++ b/src/backend/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 class ApplicationController < ActionController::API
-  # すべてのコントローラにHttpDealerをincludeする
+  # すべてのコントローラに以下のモジュールをincludeする
   include HttpDealer
+  include ErrorDealer
+  include TwitchApiDealer
 
   private
 

--- a/src/backend/app/controllers/concerns/error_dealer.rb
+++ b/src/backend/app/controllers/concerns/error_dealer.rb
@@ -4,6 +4,6 @@ module ErrorDealer
   end
 
   def validate_variable!(variable)
-    raise StandardError, "#{variable}が不正な値です" unless variable
+    raise StandardError, "変数が不正な値です" unless variable
   end
 end

--- a/src/backend/app/controllers/concerns/error_dealer.rb
+++ b/src/backend/app/controllers/concerns/error_dealer.rb
@@ -1,0 +1,9 @@
+module ErrorDealer
+  def validate_arguments!(*args)
+    raise ArgumentError, "必須の引数が不足しています" if args.any?(&:nil?)
+  end
+
+  def validate_variable!(variable)
+    raise StandardError, "#{variable}が不正な値です" unless variable
+  end
+end

--- a/src/backend/app/controllers/concerns/twitch_api_dealer.rb
+++ b/src/backend/app/controllers/concerns/twitch_api_dealer.rb
@@ -1,0 +1,58 @@
+module TwitchApiDealer
+  # 配信者IDから配信者データを取得する関数
+  def get_broadcaster_data(broadcaster_id)
+    # 引数チェック
+    validate_arguments!(broadcaster_id)
+
+    # 準備
+    uri = "https://api.twitch.tv/helix/users?id=#{broadcaster_id}"
+
+    # データ取得
+    response = get_request(twitch_api_header("app-access-token"), uri)
+    broadcaster_data = response.dig("data", 0)
+
+    # エラーハンドリング
+    validate_variable!(broadcaster_data)
+
+    # 出力
+    broadcaster_data
+  end
+
+  # クリップIDから配信者IDを取得する関数
+  def get_broadcaster_id(clip_id)
+    # 引数チェック
+    validate_arguments!(clip_id)
+
+    # 準備
+    uri = "https://api.twitch.tv/helix/clips?id=#{clip_id}"
+
+    # データ取得
+    response = get_request(twitch_api_header("app-access-token"), uri)
+    broadcaster_id = response.dig("data", 0, "broadcaster_id")
+
+    # エラーハンドリング
+    validate_variable!(broadcaster_id)
+
+    # 出力
+    broadcaster_id
+  end
+
+  # 配信者IDから配信者の最も人気なクリップの言語を取得する関数
+  def get_first_clip_language(broadcaster_id)
+    # 引数チェック
+    validate_arguments!(broadcaster_id)
+
+    # 準備
+    uri = "https://api.twitch.tv/helix/clips?broadcaster_id=#{broadcaster_id}&first=1"
+
+    # データ取得
+    response = get_request(twitch_api_header("app-access-token"), uri)
+    language = response.dig("data", 0, "language")
+
+    # エラーハンドリング
+    validate_variable!(language)
+
+    # 出力
+    language
+  end
+end

--- a/src/backend/app/controllers/concerns/twitch_api_dealer.rb
+++ b/src/backend/app/controllers/concerns/twitch_api_dealer.rb
@@ -5,7 +5,7 @@ module TwitchApiDealer
     validate_arguments!(broadcaster_id)
 
     # 準備
-    uri = "https://api.twitch.tv/helix/users?id=#{broadcaster_id}"
+    uri = "https://api.twitch.tv/helix/users?id=#{URI.encode_www_form_component(broadcaster_id)}"
 
     # データ取得
     response = get_request(twitch_api_header("app-access-token"), uri)
@@ -24,7 +24,7 @@ module TwitchApiDealer
     validate_arguments!(clip_id)
 
     # 準備
-    uri = "https://api.twitch.tv/helix/clips?id=#{clip_id}"
+    uri = "https://api.twitch.tv/helix/clips?id=#{URI.encode_www_form_component(clip_id)}"
 
     # データ取得
     response = get_request(twitch_api_header("app-access-token"), uri)
@@ -43,7 +43,7 @@ module TwitchApiDealer
     validate_arguments!(broadcaster_id)
 
     # 準備
-    uri = "https://api.twitch.tv/helix/clips?broadcaster_id=#{broadcaster_id}&first=1"
+    uri = "https://api.twitch.tv/helix/clips?broadcaster_id=#{URI.encode_www_form_component(broadcaster_id)}&first=1"
 
     # データ取得
     response = get_request(twitch_api_header("app-access-token"), uri)


### PR DESCRIPTION
## 実施タスク
broadcasters_controllerのリファクタリング

## 実施内容
- TwitchAPIに問い合わせするメソッドをtwitch_api_dealerにまとめた
- よく使用するエラーハンドリングをerror_dealerにまとめた
- 上記を利用して、メインの処理が読みやすいように、主にエラーハンドリングの位置をリファクタリング

## その他 / 備考
なし


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 入力バリデーション用のエラーハンドリング機能が追加されました。
  - Twitch APIとの連携機能が追加され、ブロードキャスター情報やクリップ言語の取得が可能になりました。

- **リファクタリング**
  - ブロードキャスター作成時のAPIデータ取得とエラーハンドリングが簡素化され、重複したロジックが削除されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->